### PR TITLE
fetch branch before push

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,4 +17,5 @@ fi
 
 branch=$(git rev-parse --abbrev-ref HEAD)
 git remote add dgit $dgiturl
+git fetch dgit $branch
 git push dgit $branch:$branch


### PR DESCRIPTION
I think this will fix the push to an existing ref, currently getting `(object not found)`